### PR TITLE
move magnification fix #7

### DIFF
--- a/lib/component/component_player.dart
+++ b/lib/component/component_player.dart
@@ -68,8 +68,8 @@ class ComponentPlayer extends SpriteComponent
 
   /// タップによる自機の移動
   void updateDeltaByTap() {
-    position = Vector2(gameRef.globalInfo.touchPosX - halfSize.x,
-        gameRef.globalInfo.touchPosY - halfSize.y);
+    position =
+        Vector2(gameRef.globalInfo.touchPosX, gameRef.globalInfo.touchPosY);
   }
 
   /// キーイベントハンドラ

--- a/lib/global_info.dart
+++ b/lib/global_info.dart
@@ -21,6 +21,9 @@ class GlobalInfo {
   /// デバイスの高さの1/4
   double deviceHeight1of4 = 0;
 
+  /// 移動倍率（タッチで移動させた距離をこの倍率をかけたものが移動距離となる）
+  double moveMagnification = 1.4;
+
   /// タッチ座標原点X
   /// TODO: 現在は随時更新しているが、タッチ開始以降変化しないようにする予定
   double touchBaseX = 0;
@@ -28,6 +31,12 @@ class GlobalInfo {
   /// タッチ座標原点Y
   /// TODO: 現在は随時更新しているが、タッチ開始以降変化しないようにする予定
   double touchBaseY = 0;
+
+  /// タッチダウン時のプレイヤー位置X
+  double playerPosXOnTouchDown = 0;
+
+  /// タッチダウン時のプレイヤー位置Y
+  double playerPosYOnTouchDown = 0;
 
   /// タッチ座標X
   double touchPosX = 0;

--- a/lib/page_game.dart
+++ b/lib/page_game.dart
@@ -39,6 +39,7 @@ class _PageGameState extends State<PageGame> {
         ? globalInfo.deviceWidth / devideNum
         : globalInfo.deviceHeight / devideNum;
     globalInfo.halfX = globalInfo.deviceWidth / 2;
+    globalInfo.moveMagnification = 1.4;
 
     return new Scaffold(
       // appBar: new AppBar(
@@ -50,15 +51,11 @@ class _PageGameState extends State<PageGame> {
           _calcTouchPos(details.localPosition);
         },
         onPointerDown: (PointerEvent details) {
+          // タッチ基本座標・タッチ時の自機位置を更新
           globalInfo.touchBaseX = details.localPosition.dx;
           globalInfo.touchBaseY = details.localPosition.dy;
-          _calcTouchPos(details.localPosition);
-        },
-        onPointerUp: (PointerEvent details) {
-          _calcTouchPos(details.localPosition);
-        },
-        onPointerCancel: (PointerEvent details) {
-          _calcTouchPos(details.localPosition);
+          globalInfo.playerPosXOnTouchDown = globalInfo.touchPosX;
+          globalInfo.playerPosYOnTouchDown = globalInfo.touchPosY;
         },
       ),
     );
@@ -66,11 +63,23 @@ class _PageGameState extends State<PageGame> {
 
   /// タッチ座標更新
   void _calcTouchPos(Offset currentPos) {
-    globalInfo.touchPosX =
-        globalInfo.touchPosX + currentPos.dx - globalInfo.touchBaseX;
-    globalInfo.touchPosY =
-        globalInfo.touchPosY + currentPos.dy - globalInfo.touchBaseY;
-    globalInfo.touchBaseX = currentPos.dx;
-    globalInfo.touchBaseY = currentPos.dy;
+    // タッチダウン座標からの差分を移動距離倍率を考慮して現在座標に反映
+    double diffX = currentPos.dx - globalInfo.touchBaseX;
+    double diffY = currentPos.dy - globalInfo.touchBaseY;
+    diffX *= globalInfo.moveMagnification;
+    diffY *= globalInfo.moveMagnification;
+    globalInfo.touchPosX = globalInfo.playerPosXOnTouchDown + diffX;
+    globalInfo.touchPosY = globalInfo.playerPosYOnTouchDown + diffY;
+    // 画面外には飛び出さないよう補正
+    if (globalInfo.touchPosX < 0) {
+      globalInfo.touchPosX = 0;
+    } else if (globalInfo.touchPosX > globalInfo.deviceWidth) {
+      globalInfo.touchPosX = globalInfo.deviceWidth;
+    }
+    if (globalInfo.touchPosY < 0) {
+      globalInfo.touchPosY = 0;
+    } else if (globalInfo.touchPosY > globalInfo.deviceHeight) {
+      globalInfo.touchPosY = globalInfo.deviceHeight;
+    }
   }
 }

--- a/lib/stage_controller.dart
+++ b/lib/stage_controller.dart
@@ -154,7 +154,7 @@ class StageController {
     // 先頭要素を取得して取り除く
     oneEnemy = enemyDataList[0];
     enemyDataList.removeAt(0);
-    print("key:${oneEnemy.key} / value:${oneEnemy.value}");
+    // print("key:${oneEnemy.key} / value:${oneEnemy.value}");
 
     Future.delayed(Duration(milliseconds: oneEnemy.key), () {
       if (!_isGameRunning) {


### PR DESCRIPTION
### 概要
現時点で操作はタッチした時と同じ座標差を維持しつつ自機が移動するが、スマホのサイズによっては大きく指を動かさないといけない。
タッチダウンした位置を起点とし、そこからの距離が離れれば離れるほど移動量を相対的に増加させることで、指の動きよりも大きく自機を移動できるようにする。

### 詳細 
現状、随時移動の起点を移動させているが、タッチダウンした座標を固定して保持しておく形に修正する事が必要。

### その他
自機が画面エリア外にも移動できてしまう問題も同時に対応した。