### PR TITLE
bullet limit fix #11

### DIFF
--- a/lib/component/component_bullet_player.dart
+++ b/lib/component/component_bullet_player.dart
@@ -10,6 +10,12 @@ import 'component_ex.dart';
 class ComponentBulletPlayer extends CircleComponent
     with CollisionCallbacks, HasGameRef<GameCore>
     implements ComponentEx {
+  /// 現在登場数
+  static var _totalAppearNum = 0;
+
+  /// 弾数制限（1以上の場合ONになる）
+  static var _BulletNumLimit = 0;
+
   /// 弾のサイズ
   var _size = 10.0;
 
@@ -75,24 +81,55 @@ class ComponentBulletPlayer extends CircleComponent
     // 弾が外枠に接触
     if (other is ScreenHitbox) {
       gameRef.remove(this);
+      onHide();
+      return;
     }
 
     final GameComponentType type = other is ComponentEx
         ? (other as ComponentEx).getType()
         : GameComponentType.typeUnknown;
 
-    // 弾が外枠に接触
-    if (other is ScreenHitbox) {
-      gameRef.remove(this);
-    } else {
-      switch (type) {
-        case GameComponentType.typeEnemy:
-          // 弾が敵機に接触
-          gameRef.remove(this);
-          break;
-        default:
-          break;
-      }
+    switch (type) {
+      case GameComponentType.typeEnemy:
+        // 弾が敵機に接触
+        gameRef.remove(this);
+        onHide();
+        break;
+      default:
+        break;
     }
+  }
+
+  /// 弾数制限値を設定
+  static void setTotalLimitNum(int limitNum) {
+    _BulletNumLimit = limitNum;
+  }
+
+  /// 登場可否
+  static bool canAppear() {
+    bool result = true;
+    if (_BulletNumLimit > 0 && _totalAppearNum >= _BulletNumLimit) {
+      result = false;
+    }
+    return result;
+  }
+
+  /// 登場ハンドラ
+  static void onAppend() {
+    if (_BulletNumLimit > 0 && _totalAppearNum <= _BulletNumLimit) {
+      _totalAppearNum += 1;
+    }
+  }
+
+  /// 非表示ハンドラ
+  static void onHide() {
+    if (_BulletNumLimit > 0 && _totalAppearNum > 0) {
+      _totalAppearNum -= 1;
+    }
+  }
+
+  /// 登場数クリア
+  static void clearAppendNum() {
+    _totalAppearNum = 0;
   }
 }

--- a/lib/component/component_player.dart
+++ b/lib/component/component_player.dart
@@ -48,8 +48,15 @@ class ComponentPlayer extends SpriteComponent
     // 矩形当たり判定設定
     add(CircleHitbox());
 
+    // 弾数制限
+    ComponentBulletPlayer.setTotalLimitNum(3);
+
+    // 定期的に弾を発射
     timer.startTime(200, () {
-      gameRef.add(ComponentBulletPlayer(position));
+      if (ComponentBulletPlayer.canAppear()) {
+        ComponentBulletPlayer.onAppend();
+        gameRef.add(ComponentBulletPlayer(position));
+      }
     });
   }
 

--- a/lib/game_core.dart
+++ b/lib/game_core.dart
@@ -58,6 +58,9 @@ class GameCore extends FlameGame
   Future<void> onLoad() async {
     await super.onLoad();
 
+    // 弾数制限を初期化
+    ComponentBulletPlayer.clearAppendNum();
+
     timerController = TimerController();
     stageController = StageController();
 
@@ -205,6 +208,8 @@ class GameCore extends FlameGame
                     for (int i = _sprites.length - 1; i >= 0; i--) {
                       remove(_sprites[i]);
                     }
+                    // 弾数制限を初期化
+                    ComponentBulletPlayer.clearAppendNum();
                     // 自機を画面に追加
                     charPlayer = ComponentPlayer();
                     add(charPlayer);


### PR DESCRIPTION
### 概要
自機の発射する弾数を画面内にN発とする制限を実装

### 詳細 
ボス敵などに、近づいて（リスクを冒して）弾を撃ち込む事で早く倒せるなどプレイの幅につながるはず。

### その他
とりあえず、画面内に自機の弾は3発とした。
今後、弾の種類を変更できるようにするなど、自機のパワーアップの際などには、弾の特性として画面内弾数制限も変えられるようになる、はず。